### PR TITLE
fix sandbox scoping and imports, add list_open_views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .zed
 pyrightconfig.json
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   AST validator already blocked direct dangerous calls; this closes the
   reach-via-dict gap too. Legitimate `import struct` / `class` statements now
   work because the curated builtins include `__import__` and `__build_class__`.
-
+- Expose __orig_import__ in sandbox builtins to stop shiboken SIGABRT
+  A sandboxed `import binaryninjaui` (or any transitive PySide6/shiboken6
+  import) aborted the whole Binary Ninja process with
+  `Fatal Python error: libshiboken: builtins has no "__orig_import__"
+  function` -> SIGABRT (exit 134).
+ 
 ## [0.1.3] - 2026-01-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-08-07
+
+### Added
+
+- `binja.list_open_views()` to enumerate every binary open in the GUI tabs,
+  returning filename, address range, function count, and which view the API is
+  pinned to. Replaces the manual `UIContext` incantation agents previously had
+  to paste to discover open binaries (distinct from `list_files()`, which lists
+  workspace files).
+
+### Fixed
+
+- The `execute` sandbox no longer raises `NameError` for comprehensions,
+  generator expressions, helper `def`s referencing top-level variables, and
+  `import` statements used inside helpers. The root cause was a two-namespace
+  `exec(code, globals, {})` that stranded top-level names in an isolated locals
+  dict nested scopes couldn't see; switched to a single namespace.
+- Tightened the sandbox by setting `__builtins__` to a curated dict. Previously
+  `exec` silently injected the full builtins (including `open`, `eval`, `exec`,
+  `__import__`) into globals, so the two-namespace form bought no security. The
+  AST validator already blocked direct dangerous calls; this closes the
+  reach-via-dict gap too. Legitimate `import struct` / `class` statements now
+  work because the curated builtins include `__import__` and `__build_class__`.
+
 ## [0.1.3] - 2026-01-08
 
 ### Added

--- a/bridge/mcp_bridge.py
+++ b/bridge/mcp_bridge.py
@@ -94,7 +94,7 @@ def handle_initialize(params: dict) -> dict:
         },
         "serverInfo": {
             "name": "binja-codemode-mcp",
-            "version": "0.1.3",
+            "version": "0.1.4",
         },
         "_meta": {
             "description": "Binary Ninja Code Mode MCP Server for LLM-assisted reverse engineering",

--- a/plugin.json
+++ b/plugin.json
@@ -15,7 +15,7 @@
     "Linux": "1. Install via Plugin Manager, or copy to ~/.binaryninja/plugins/",
     "Windows": "1. Install via Plugin Manager, or copy to %APPDATA%\\Binary Ninja\\plugins\\"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "Austyn Krutsinger",
   "minimumbinaryninjaversion": 4000
 }

--- a/plugin/api.py
+++ b/plugin/api.py
@@ -740,6 +740,57 @@ class BinjaAPI:
         """Delete a workspace file."""
         return self._workspace.delete(name)
 
+    def list_open_views(self) -> list[dict]:
+        """Enumerate every binary open in the Binary Ninja GUI tabs.
+
+        Returns one dict per open view: {filename, short_name, start, end,
+        function_count, is_active}. `is_active` marks the view this API is
+        currently pinned to (``self._bv``). Returns an empty list (and never
+        raises) when the UI is unavailable - e.g. headless/no-GUI runs where
+        ``binaryninjaui`` cannot be imported.
+
+        Note: ``list_files()`` lists workspace files, NOT open binaries - the
+        two are unrelated and the names are easy to confuse.
+        """
+        try:
+            import binaryninjaui
+        except Exception:
+            return []
+
+        try:
+            active_short = self._bv.file.filename.split("/")[-1]
+        except Exception:
+            active_short = None
+
+        views = []
+        try:
+            for ctx in binaryninjaui.UIContext.allContexts():
+                get_tabs = getattr(ctx, "getTabs", None)
+                tabs = get_tabs() if callable(get_tabs) else []
+                for tab in tabs:
+                    vf = ctx.getViewFrameForTab(tab)
+                    if vf is None:
+                        continue
+                    bv = getattr(vf, "getCurrentBinaryView", lambda: None)()
+                    if bv is None:
+                        continue
+                    short = bv.file.filename.split("/")[-1]
+                    views.append(
+                        {
+                            "filename": bv.file.filename,
+                            "short_name": short,
+                            "start": bv.start,
+                            "end": bv.end,
+                            "function_count": len(list(bv.functions)),
+                            "is_active": short == active_short,
+                        }
+                    )
+        except Exception:
+            # A UI API change should not crash the sandbox; return what we have.
+            pass
+
+        return views
+
     # =========================================================================
     # Skills Operations
     # =========================================================================

--- a/plugin/executor.py
+++ b/plugin/executor.py
@@ -186,9 +186,34 @@ class CodeExecutor:
         # validator blocks `__import__` (in _FORBIDDEN_ATTRIBUTES) and direct
         # forbidden-module imports, so `import os` / `__import__("os")` stay
         # blocked while legitimate `import struct` works, including inside helpers.
-        safe_builtins["__import__"] = builtins.__import__
+        #
+        # Resolve the TRUE original import function, not whatever
+        # builtins.__import__ currently is. PySide6's feature system
+        # (imported transitively via binaryninjaui -> shiboken6) monkeypatches
+        # builtins.__import__ with its own __feature_import__ hook and stashes
+        # the real one as builtins.__orig_import__. If we copied the hook into
+        # the sandbox, every `import` would route through the hook, which itself
+        # calls __orig_import__ - and if we'd set both to the hook that's
+        # instant infinite recursion (RecursionError on `import binaryninjaui`).
+        # Using the unhooked original bypasses the feature hook for sandbox
+        # code (which has no need for PySide feature selection) and terminates.
+        _real_import = getattr(builtins, "__orig_import__", None) or builtins.__import__
+        safe_builtins["__import__"] = _real_import
         safe_builtins["__build_class__"] = builtins.__build_class__
         safe_builtins["__name__"] = "__main__"
+        # `__orig_import__` is the name shiboken6 looks up on the active frame's
+        # `__builtins__` during its module init (PyDict_GetItemString(builtins,
+        # "__orig_import__")). On a miss it calls Py_FatalError ->
+        # `Fatal Python error: libshiboken: builtins has no "__orig_import__"
+        # function`, which aborts the whole Binary Ninja process (SIGABRT, exit
+        # 134). Because our curated dict replaced `__builtins__`, a sandboxed
+        # `import binaryninjaui` (e.g. a pasted view-enumerator snippet) used to
+        # take the container down with no recovery short of a full restart.
+        # Mirror the same unhooked original here so the lookup resolves. This
+        # opens no new path: it is the same vetted import function, and the AST
+        # validator still blocks forbidden module names at the `import`
+        # statement level and `__import__` as a direct call/name.
+        safe_builtins["__orig_import__"] = _real_import
 
         restricted_globals = {
             "__builtins__": safe_builtins,

--- a/plugin/executor.py
+++ b/plugin/executor.py
@@ -1,6 +1,7 @@
 """Code validation and execution for Code Mode MCP."""
 
 import ast
+import builtins
 import threading
 import time
 import traceback
@@ -151,65 +152,51 @@ class CodeExecutor:
             elapsed = time.time() - start_time
             print(f"[{elapsed:.1f}s]", *args, file=stdout_capture, **kwargs)
 
-        # Restricted globals
+        # Restricted globals. We build a single namespace (no separate locals) so
+        # that top-level assignments and imports are visible to nested scopes -
+        # comprehensions, generator expressions, and helper `def`s. The old
+        # `exec(code, globals, {})` form landed top-level names in an isolated
+        # locals dict that nested scopes could not see, so every comprehension or
+        # helper referencing a top-level variable raised NameError.
+        #
+        # `__builtins__` is set EXPLICITLY to a curated dict. If it were omitted,
+        # `exec` would silently inject the FULL builtins (including `open`,
+        # `eval`, `exec`, `__import__`) - which is what happened before, making
+        # the sandbox looser than it appeared. The AST validator blocks direct
+        # calls to the dangerous names; restricting `__builtins__` closes the
+        # reach-via-dict gap too.
+        safe_builtin_names = (
+            "len", "range", "enumerate", "zip", "map", "filter", "sorted",
+            "reversed", "list", "dict", "set", "tuple", "frozenset", "str",
+            "int", "float", "bool", "bytes", "bytearray", "hex", "bin", "oct",
+            "ord", "chr", "abs", "min", "max", "sum", "round", "pow", "divmod",
+            "any", "all", "isinstance", "issubclass", "hasattr", "getattr",
+            "setattr", "delattr", "repr", "format", "slice", "iter", "next",
+            "type", "dir", "callable", "hash", "id", "ascii", "object",
+            "super", "memoryview", "complex", "staticmethod", "classmethod",
+            "property",
+            # Exceptions commonly caught by real analysis snippets
+            "Exception", "ValueError", "TypeError", "KeyError", "IndexError",
+            "AttributeError", "RuntimeError", "StopIteration", "NameError",
+            "NotImplementedError",
+        )
+        safe_builtins = {name: getattr(builtins, name) for name in safe_builtin_names}
+        # `import` statements need __import__; `class` statements need
+        # __build_class__. Neither is reachable as a direct call/name - the AST
+        # validator blocks `__import__` (in _FORBIDDEN_ATTRIBUTES) and direct
+        # forbidden-module imports, so `import os` / `__import__("os")` stay
+        # blocked while legitimate `import struct` works, including inside helpers.
+        safe_builtins["__import__"] = builtins.__import__
+        safe_builtins["__build_class__"] = builtins.__build_class__
+        safe_builtins["__name__"] = "__main__"
+
         restricted_globals = {
+            "__builtins__": safe_builtins,
             "binja": self.api,
             "print": progress_print,
-            # Safe built-ins
-            "len": len,
-            "range": range,
-            "enumerate": enumerate,
-            "zip": zip,
-            "map": map,
-            "filter": filter,
-            "sorted": sorted,
-            "reversed": reversed,
-            "list": list,
-            "dict": dict,
-            "set": set,
-            "tuple": tuple,
-            "frozenset": frozenset,
-            "str": str,
-            "int": int,
-            "float": float,
-            "bool": bool,
-            "bytes": bytes,
-            "bytearray": bytearray,
-            "hex": hex,
-            "bin": bin,
-            "oct": oct,
-            "ord": ord,
-            "chr": chr,
-            "abs": abs,
-            "min": min,
-            "max": max,
-            "sum": sum,
-            "round": round,
-            "pow": pow,
-            "divmod": divmod,
-            "any": any,
-            "all": all,
-            "isinstance": isinstance,
-            "issubclass": issubclass,
-            "hasattr": hasattr,
-            "getattr": getattr,
-            "setattr": setattr,
-            "repr": repr,
-            "format": format,
-            "slice": slice,
-            "iter": iter,
-            "next": next,
             "None": None,
             "True": True,
             "False": False,
-            # Exceptions
-            "Exception": Exception,
-            "ValueError": ValueError,
-            "TypeError": TypeError,
-            "KeyError": KeyError,
-            "IndexError": IndexError,
-            "AttributeError": AttributeError,
-            "RuntimeError": RuntimeError,
         }
 
         # Execute with timeout
@@ -217,7 +204,7 @@ class CodeExecutor:
 
         def run_code():
             try:
-                exec(code, restricted_globals, {})
+                exec(code, restricted_globals)
                 result_holder["result"] = stdout_capture.getvalue()
             except Exception as e:
                 result_holder["error"] = (

--- a/stubs.py
+++ b/stubs.py
@@ -118,8 +118,18 @@ binja.delete_function_comment(func: str|int) -> bool
 ## WORKSPACE (file persistence)
 binja.write_file(name: str, content: str) -> bool
 binja.read_file(name: str) -> str|None
-binja.list_files() -> list[dict]  # [{name, size, modified}, ...]
+binja.list_files() -> list[dict]  # [{name, size, modified}, ...] - WORKSPACE files, NOT open binaries
 binja.delete_file(name: str) -> bool
+
+## OPEN VIEWS (which binaries are loaded)
+binja.list_open_views() -> list[dict]  # [{filename, short_name, start, end, function_count, is_active}, ...]
+# Enumerates every binary open in the GUI. `is_active` marks the view `binja`
+# is pinned to. To operate on a non-active view, grab it from the raw API:
+#   import binaryninjaui
+#   ctx = binaryninjaui.UIContext.allContexts()[0]
+#   views = {t.getCurrentBinaryView().file.filename.split('/')[-1]: t.getCurrentBinaryView()
+#            for t in (ctx.getViewFrameForTab(t) for t in ctx.getTabs())}
+# then use e.g. views['Client.exe.bndb'].read(addr, n) directly. (Returns [] in headless/no-UI runs.)
 
 ## SKILLS (reusable code)
 binja.save_skill(name: str, code: str, description: str) -> bool
@@ -132,6 +142,15 @@ binja.find_functions_calling_unsafe(unsafe_patterns=None) -> list[dict]  # Defau
 binja.get_function_complexity(func: str|int) -> dict|None  # {name, address, size, basic_blocks, cyclomatic_complexity, callers_count, callees_count, instruction_count}
 
 # Note: Many functions return None on failure - always check before using!
+#
+# Code runs in a normal Python namespace: top-level variables, comprehensions,
+# generator expressions, helper `def`s, `import` (including inside helpers), and
+# `class` statements all work as expected. You do NOT need to inline helpers or
+# avoid comprehensions - define a top-level `x` and reference it from a helper
+# or a `[i for i in range(x)]` freely. Forbidden modules (os, subprocess, ...)
+# and builtins (open, eval, exec, __import__ direct calls) are blocked at parse
+# time; use `int.from_bytes(b, "little")` only when you prefer it, not because
+# `struct` is unavailable - `import struct` is allowed.
 """
 
     return (

--- a/tests/test_executor_sandbox.py
+++ b/tests/test_executor_sandbox.py
@@ -207,6 +207,72 @@ def test_stop_iteration_catchable():
     assert "caught" in r.output
 
 
+# ---------------------------------------------------------------------------
+# shiboken/PySide safety: a curated __builtins__ that omits __orig_import__
+# used to abort the host process when sandbox code imported a C extension
+# (e.g. binaryninjaui via shiboken6) that looks it up. __orig_import__ must be
+# present and resolve to the same import machinery, while direct __import__
+# stays AST-blocked and forbidden modules stay blocked.
+# ---------------------------------------------------------------------------
+
+
+def test_orig_import_present_in_sandbox_builtins():
+    """Sandbox code can't name `__builtins__` (AST-blocked), but it CAN call
+    `import` (which the import statement routes through __import__, and which
+    shiboken resolves via __orig_import__). The behavioral proof that
+    __orig_import__ is wired up: a plain `import` of an allowed stdlib module
+    succeeds AND a lookup of `__orig_import__` through the import system's own
+    channel works. We exercise the channel shiboken uses by importing a module
+    whose import triggers a re-entrant import lookup - `import` itself is the
+    surface, and if __orig_import__ were absent an importing C extension would
+    abort us, but here we just confirm allowed imports still resolve (the
+    regression is the absence of the key, tested directly below)."""
+    ex = _make_executor()
+    r = ex.execute("import struct\nprint(struct.calcsize('<I'))")
+    assert r.success, r.error
+    assert "4" in r.output
+
+
+def test_orig_import_key_present_in_builtins_directly():
+    """Directly assert the curated builtins dict carries __orig_import__.
+
+    This is the exact key shiboken6 looks up; its absence is what caused
+    `Fatal Python error: libshiboken: builtins has no "__orig_import__"` ->
+    SIGABRT -> container death. We reach the dict the executor builds by
+    importing a module inside the sandbox and reflecting on its
+    `__builtins__`... but `__builtins__` is AST-blocked as an attribute.
+    Instead, drive a sandbox import through the import statement and confirm
+    no abort; and separately, assert at the Python level by reconstructing the
+    builtins the way the executor does. The latter is the real regression
+    guard: if someone removes the `__orig_import__` line, this fails."""
+    module = _load_executor()
+    # Re-derive the curated builtins exactly as CodeExecutor.execute does, by
+    # inspecting the source-built dict through a sandboxed exec that captures
+    # its own __builtins__ via the one channel not AST-blocked: an imported
+    # module's globals. `struct` is allowed; its module object exposes the
+    # frame-builtins-agnostic machinery, but the cleanest check is to confirm
+    # an allowed import works (above) and that the executor's source contains
+    # the assignment. Guard the source-level contract:
+    import inspect
+
+    src = inspect.getsource(module.CodeExecutor.execute)
+    assert '"__orig_import__"' in src or "'__orig_import__'" in src, (
+        "executor must set __orig_import__ on the curated builtins, or "
+        "sandboxed imports of shiboken-backed C extensions (binaryninjaui) "
+        "abort the host process with SIGABRT"
+    )
+
+
+def test_direct_dunder_import_still_blocked_with_orig_import():
+    """Adding __orig_import__ must NOT unblock a direct `__import__('os')`
+    call - the AST validator blocks the __import__ name regardless, and
+    __orig_import__ is not a name the sandbox exposes for direct calling."""
+    ex = _make_executor()
+    r = ex.execute("os = __import__('os')\nprint(os.getcwd())")
+    assert not r.success
+    assert "__import__" in r.error
+
+
 if __name__ == "__main__":
     # Minimal runner for environments without pytest.
     import traceback

--- a/tests/test_executor_sandbox.py
+++ b/tests/test_executor_sandbox.py
@@ -1,0 +1,225 @@
+"""Regression tests for the Code Mode MCP ``execute`` sandbox.
+
+These run under plain ``python3`` with NO Binary Ninja installed: the executor
+module's only runtime imports are the standard library, and its ``BinjaAPI``
+dependency is a ``TYPE_CHECKING``-only import, so we load it by file path and
+hand it a dummy API object.
+
+Two things must never regress:
+
+1. **Scoping** - top-level variables, comprehensions, generator expressions,
+   helper ``def``s, ``import`` inside helpers, and ``class`` statements all
+   work. (Previously ``exec(code, globals, {})`` stranded top-level names in an
+   isolated locals dict, so every one of these raised ``NameError``.)
+2. **Security** - ``open``, ``eval``, ``exec``, direct ``__import__``, forbidden
+   module imports, and ``__subclasses__``/``__bases__`` escapes are blocked at
+   validation. (Previously the sandbox ALSO leaked the full ``__builtins__`` via
+   ``exec`` auto-injection; the curated ``__builtins__`` must keep them out.)
+
+Run: ``python3 -m pytest tests/test_executor_sandbox.py`` or
+``python3 tests/test_executor_sandbox.py``.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_executor():
+    """Load plugin/executor.py without importing the binaryninja-dependent package."""
+    if "plugin" not in sys.modules:
+        pkg = types.ModuleType("plugin")
+        pkg.__path__ = [str(REPO_ROOT / "plugin")]
+        sys.modules["plugin"] = pkg
+    if "plugin.api" not in sys.modules:
+        api = types.ModuleType("plugin.api")
+
+        class BinjaAPI:  # pragma: no cover - only needed for type checking
+            pass
+
+        api.BinjaAPI = BinjaAPI
+        sys.modules["plugin.api"] = api
+
+    mod_path = REPO_ROOT / "plugin" / "executor.py"
+    spec = importlib.util.spec_from_file_location("plugin.executor", mod_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["plugin.executor"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeAPI:
+    """Stand-in for BinjaAPI - the executor never calls it for these tests."""
+
+
+def _make_executor():
+    module = _load_executor()
+    return module.CodeExecutor(_FakeAPI(), max_output_bytes=100_000, timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Scoping: everything below used to raise NameError before the fix.
+# ---------------------------------------------------------------------------
+
+
+def test_helper_references_top_level_variable():
+    ex = _make_executor()
+    r = ex.execute("x = 5\ndef h():\n    return x\nprint(h())")
+    assert r.success, r.error
+    assert "5" in r.output
+
+
+def test_comprehension_references_top_level_variable():
+    ex = _make_executor()
+    r = ex.execute("x = 5\nprint([i for i in range(x)])")
+    assert r.success, r.error
+    assert "[0, 1, 2, 3, 4]" in r.output
+
+
+def test_generator_expression_references_top_level_variable():
+    ex = _make_executor()
+    r = ex.execute("x = 4\nprint(sum(i for i in range(x)))")
+    assert r.success, r.error
+    assert "6" in r.output
+
+
+def test_import_inside_helper():
+    ex = _make_executor()
+    r = ex.execute(
+        "import struct\ndef h():\n    return struct.pack('<I', 1).hex()\nprint(h())"
+    )
+    assert r.success, r.error
+    assert "01000000" in r.output
+
+
+def test_class_statement():
+    ex = _make_executor()
+    r = ex.execute("class C:\n    def __init__(self, v):\n        self.v = v\nprint(C(7).v)")
+    assert r.success, r.error
+    assert "7" in r.output
+
+
+def test_nested_helper_closure():
+    ex = _make_executor()
+    r = ex.execute(
+        "total = 0\n"
+        "def outer(n):\n"
+        "    def inner(i):\n"
+        "        return i * 2\n"
+        "    return sum(inner(i) for i in range(n))\n"
+        "total = outer(3)\n"
+        "print(total)"
+    )
+    assert r.success, r.error
+    assert "6" in r.output  # 0*2 + 1*2 + 2*2
+
+
+# ---------------------------------------------------------------------------
+# Security: these must be rejected at validation, not executed.
+# ---------------------------------------------------------------------------
+
+
+def test_open_blocked():
+    ex = _make_executor()
+    r = ex.execute("f = open('/etc/passwd')\nprint(f.read(5))")
+    assert not r.success
+    assert "open" in r.error
+
+
+def test_eval_blocked():
+    ex = _make_executor()
+    r = ex.execute("eval('1+1')")
+    assert not r.success
+    assert "eval" in r.error
+
+
+def test_exec_blocked():
+    ex = _make_executor()
+    r = ex.execute("exec('print(1)')")
+    assert not r.success
+    assert "exec" in r.error
+
+
+def test_direct_dunder_import_blocked():
+    ex = _make_executor()
+    r = ex.execute("os = __import__('os')\nprint(os.getcwd())")
+    assert not r.success
+    assert "__import__" in r.error
+
+
+def test_forbidden_module_import_blocked():
+    ex = _make_executor()
+    r = ex.execute("import os\nprint(os.getcwd())")
+    assert not r.success
+    assert "os" in r.error
+
+
+def test_subclasses_escape_blocked():
+    ex = _make_executor()
+    r = ex.execute("print([].__class__.__bases__[0].__subclasses__())")
+    assert not r.success
+    assert "__subclasses__" in r.error or "__bases__" in r.error
+
+
+def test_builtins_not_leaked():
+    """The curated __builtins__ must NOT contain the dangerous builtins, even
+    though `exec` would auto-inject the FULL builtins if __builtins__ were
+    absent (which is the pre-fix behavior this replaces).
+
+    We can't reference ``__builtins__`` by name in sandbox code (the AST
+    validator blocks it), so prove it behaviorally: ``globals``/``vars`` are
+    NOT in the curated set and are NOT in _FORBIDDEN_ATTRIBUTES, so they would
+    resolve only if the full builtins leaked. They must NameError; ``type``
+    (in the curated set) must work. ``open``/``eval``/``exec`` are covered by
+    the AST-blocked tests above, but absence here is the belt-and-braces check
+    that the curated dict - not the auto-injected one - is in effect.
+    """
+    ex = _make_executor()
+    r = ex.execute("print(type(5).__name__)")  # curated -> works
+    assert r.success, r.error
+    assert "int" in r.output
+
+    for escape in ("globals", "vars", "input", "breakpoint"):
+        r = ex.execute(f"print({escape}())")
+        assert not r.success, f"{escape} should be absent from the curated builtins"
+        assert "NameError" in r.error
+
+
+# ---------------------------------------------------------------------------
+# Sanity: whitelisted use still works.
+# ---------------------------------------------------------------------------
+
+
+def test_whitelisted_builtins_work():
+    ex = _make_executor()
+    r = ex.execute("print(hex(255), ord('A'), sum([1, 2, 3]))")
+    assert r.success, r.error
+    assert "0xff 65 6" in r.output
+
+
+def test_stop_iteration_catchable():
+    ex = _make_executor()
+    r = ex.execute("try:\n    raise StopIteration\nexcept StopIteration:\n    print('caught')")
+    assert r.success, r.error
+    assert "caught" in r.output
+
+
+if __name__ == "__main__":
+    # Minimal runner for environments without pytest.
+    import traceback
+
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    passed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+            passed += 1
+        except Exception:
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"\n{passed}/{len(fns)} passed")
+    sys.exit(0 if passed == len(fns) else 1)


### PR DESCRIPTION
this fixes a crash caused by list_views due to missing expose("__orig_import__") which would cause a crash due to shiboken, also adjust scoping so we might utilize more functionality while maintaining the same safety.

also added list_open_views which was a different way to list open views before missing expose, which i left out as it helps and provides additional information.

PS.: yes this was coded with assist of an Agent, but tested and confirmed extensively on my heavy load setup, works in our docker container as well, reviewed by me after each push, we might want to correct the CHANGELOG.md tho, it doesnt follow the same style, please review ill correct if needed